### PR TITLE
Add a privacy preserving feature for public key exports

### DIFF
--- a/doc/btc.asc
+++ b/doc/btc.asc
@@ -20,6 +20,8 @@ application. It is based on the HW.1 firmware specification detailed on https://
 ==== Description
 
 This command returns the public key and Base58 encoded address for the given BIP 32 path.
+The Base58 encoded address can be displayed on the device screen. 
+This call might trigger a user validation (with or without token) if the device has the public key protection setting enabled.
 
 ==== Coding
 
@@ -31,6 +33,8 @@ This command returns the public key and Base58 encoded address for the given BIP
 |   E0  |   40   |  00 : do not display the address
 
                     01 : display the address
+
+                    02 : display a validation token
 
                  |   00 : return a legacy address
 
@@ -48,6 +52,7 @@ This command returns the public key and Base58 encoded address for the given BIP
 | First derivation index (big endian)                                               | 4
 | ...                                                                               | 4
 | Last derivation index (big endian)                                                | 4
+| Optional Validation token (big endian)                                            | 4
 |==============================================================================================================================
 
 'Output data'

--- a/include/btchip_filesystem.h
+++ b/include/btchip_filesystem.h
@@ -68,6 +68,8 @@ typedef struct btchip_storage_s {
 
     unsigned char fidoTransport;
 
+    uint8_t pubKeyRequestRestriction;
+
 } btchip_storage_t;
 
 // the global nvram memory variable

--- a/src/btchip_apdu_get_wallet_public_key.c
+++ b/src/btchip_apdu_get_wallet_public_key.c
@@ -40,8 +40,8 @@ unsigned short btchip_apdu_get_wallet_public_key() {
     uint32_t request_token;
     unsigned char chainCode[32];
     bool display = (G_io_apdu_buffer[ISO_OFFSET_P1] == P1_DISPLAY);
-    bool display_request_token = N_btchip.pubKeyRequestRestriction && (G_io_apdu_buffer[ISO_OFFSET_P1] == P1_REQUEST_TOKEN);
-    bool require_user_approval = N_btchip.pubKeyRequestRestriction && !(display_request_token || display);
+    bool display_request_token = N_btchip.pubKeyRequestRestriction && (G_io_apdu_buffer[ISO_OFFSET_P1] == P1_REQUEST_TOKEN) && G_io_apdu_media == IO_APDU_MEDIA_U2F;
+    bool require_user_approval = N_btchip.pubKeyRequestRestriction && !(display_request_token || display) && G_io_apdu_media == IO_APDU_MEDIA_U2F;
     bool segwit = (G_io_apdu_buffer[ISO_OFFSET_P2] == P2_SEGWIT);
     bool nativeSegwit = (G_io_apdu_buffer[ISO_OFFSET_P2] == P2_NATIVE_SEGWIT);
     bool cashAddr = (G_io_apdu_buffer[ISO_OFFSET_P2] == P2_CASHADDR);
@@ -179,7 +179,7 @@ unsigned short btchip_apdu_get_wallet_public_key() {
             return BTCHIP_SW_INCORRECT_DATA;
         }
     }
-    else if(request_token)
+    else if(display_request_token)
     {
         // Hax, avoid wasting space
         snprintf(G_io_apdu_buffer + 200, 9, "%02x", request_token);

--- a/src/btchip_apdu_get_wallet_public_key.c
+++ b/src/btchip_apdu_get_wallet_public_key.c
@@ -25,6 +25,7 @@
 
 #define P1_NO_DISPLAY 0x00
 #define P1_DISPLAY 0x01
+#define P1_REQUEST_TOKEN 0x02
 
 #define P2_LEGACY 0x00
 #define P2_SEGWIT 0x01
@@ -36,8 +37,11 @@ unsigned short btchip_apdu_get_wallet_public_key() {
     unsigned char uncompressedPublicKeys =
         ((N_btchip.bkp.config.options & BTCHIP_OPTION_UNCOMPRESSED_KEYS) != 0);
     unsigned char keyPath[MAX_BIP32_PATH_LENGTH];
+    uint32_t request_token;
     unsigned char chainCode[32];
     bool display = (G_io_apdu_buffer[ISO_OFFSET_P1] == P1_DISPLAY);
+    bool display_request_token = N_btchip.pubKeyRequestRestriction && (G_io_apdu_buffer[ISO_OFFSET_P1] == P1_REQUEST_TOKEN);
+    bool require_user_approval = N_btchip.pubKeyRequestRestriction && !(display_request_token || display);
     bool segwit = (G_io_apdu_buffer[ISO_OFFSET_P2] == P2_SEGWIT);
     bool nativeSegwit = (G_io_apdu_buffer[ISO_OFFSET_P2] == P2_NATIVE_SEGWIT);
     bool cashAddr = (G_io_apdu_buffer[ISO_OFFSET_P2] == P2_CASHADDR);
@@ -45,6 +49,7 @@ unsigned short btchip_apdu_get_wallet_public_key() {
     switch (G_io_apdu_buffer[ISO_OFFSET_P1]) {
     case P1_NO_DISPLAY:
     case P1_DISPLAY:
+    case P1_REQUEST_TOKEN:
         break;
     default:
         return BTCHIP_SW_INCORRECT_P1_P2;
@@ -72,6 +77,11 @@ unsigned short btchip_apdu_get_wallet_public_key() {
     }
     os_memmove(keyPath, G_io_apdu_buffer + ISO_OFFSET_CDATA,
                MAX_BIP32_PATH_LENGTH);
+
+    if(display_request_token){
+        uint8_t request_token_offset = ISO_OFFSET_CDATA + G_io_apdu_buffer[ISO_OFFSET_CDATA]*4 + 1;
+        request_token = btchip_read_u32(G_io_apdu_buffer + request_token_offset, true, true);
+    }
 
     SB_CHECK(N_btchip.bkp.config.operationMode);
     switch (SB_GET(N_btchip.bkp.config.operationMode)) {
@@ -164,6 +174,27 @@ unsigned short btchip_apdu_get_wallet_public_key() {
         G_io_apdu_buffer[200 + keyLength] = '\0';
         btchip_context_D.io_flags |= IO_ASYNCH_REPLY;
         if (!btchip_bagl_display_public_key()) {
+            btchip_context_D.io_flags &= ~IO_ASYNCH_REPLY;
+            btchip_context_D.outLength = 0;
+            return BTCHIP_SW_INCORRECT_DATA;
+        }
+    }
+    else if(request_token)
+    {
+        // Hax, avoid wasting space
+        snprintf(G_io_apdu_buffer + 200, 9, "%02x", request_token);
+        G_io_apdu_buffer[200 + 8] = '\0';
+        btchip_context_D.io_flags |= IO_ASYNCH_REPLY;
+        if (!btchip_bagl_display_token()) {
+            btchip_context_D.io_flags &= ~IO_ASYNCH_REPLY;
+            btchip_context_D.outLength = 0;
+            return BTCHIP_SW_INCORRECT_DATA;
+        }
+    }
+    else if(require_user_approval)
+    {
+        btchip_context_D.io_flags |= IO_ASYNCH_REPLY;
+        if (!btchip_bagl_request_pubkey_approval()) {
             btchip_context_D.io_flags &= ~IO_ASYNCH_REPLY;
             btchip_context_D.outLength = 0;
             return BTCHIP_SW_INCORRECT_DATA;

--- a/src/btchip_context.c
+++ b/src/btchip_context.c
@@ -72,8 +72,9 @@ void btchip_context_init() {
         SB_CHECK(N_btchip.bkp.config.operationMode);
     }
     if (!N_btchip.storageInitialized) {
-        unsigned char initialized = 1;
+        unsigned char initialized = 1, denied=0;
 
+        nvm_write((void *)&N_btchip.pubKeyRequestRestriction, &denied, 1);
         nvm_write((void *)&N_btchip.storageInitialized, &initialized, 1);
     }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -119,6 +119,7 @@ unsigned int
 io_seproxyhal_touch_message_signature_verify_ok(const bagl_element_t *e);
 unsigned int io_seproxyhal_touch_display_cancel(const bagl_element_t *e);
 unsigned int io_seproxyhal_touch_display_ok(const bagl_element_t *e);
+unsigned int io_seproxyhal_touch_settings(const bagl_element_t *e);
 unsigned int io_seproxyhal_touch_exit(const bagl_element_t *e);
 void ui_idle(void);
 
@@ -178,11 +179,13 @@ const bagl_element_t ui_idle_blue[] = {
      NULL,
      NULL,
      NULL},
+     // Settings icon
+     {{BAGL_RECTANGLE | BAGL_FLAG_TOUCHABLE, 0x00,   0,  19,  56,  44, 0, 0, BAGL_FILL, COLOR_APP, 
+     COLOR_APP_LIGHT, BAGL_FONT_SYMBOLS_0|BAGL_FONT_ALIGNMENT_CENTER|BAGL_FONT_ALIGNMENT_MIDDLE, 0 },
+    BAGL_FONT_SYMBOLS_0_SETTINGS, 0, COLOR_APP, 0xFFFFFF, io_seproxyhal_touch_settings, NULL, NULL},
+
     {{BAGL_RECTANGLE | BAGL_FLAG_TOUCHABLE, 0x00, 264, 19, 56, 44, 0, 0,
-      BAGL_FILL, COLOR_APP, COLOR_APP_LIGHT,
-      BAGL_FONT_SYMBOLS_0 | BAGL_FONT_ALIGNMENT_CENTER |
-          BAGL_FONT_ALIGNMENT_MIDDLE,
-      0},
+     BAGL_FILL, COLOR_APP, COLOR_APP_LIGHT, BAGL_FONT_SYMBOLS_0 | BAGL_FONT_ALIGNMENT_CENTER | BAGL_FONT_ALIGNMENT_MIDDLE, 0},
      BAGL_FONT_SYMBOLS_0_DASHBOARD,
      0,
      COLOR_APP,
@@ -242,11 +245,88 @@ unsigned int ui_idle_blue_button(unsigned int button_mask,
                                  unsigned int button_mask_counter) {
     return 0;
 }
+
+const bagl_element_t * ui_settings_blue_toggle_pubKeyRequestRestriction(const bagl_element_t * e) {
+    // swap setting and request redraw of settings elements
+    uint8_t setting = N_btchip.pubKeyRequestRestriction?0:1;
+    nvm_write(&N_btchip.pubKeyRequestRestriction, (void*)&setting, sizeof(uint8_t));
+     // only refresh settings mutable drawn elements
+    UX_REDISPLAY_IDX(7);
+     // won't redisplay the bagl_none
+    return 0;
+}
+ // don't perform any draw/color change upon finger event over settings
+const bagl_element_t* ui_settings_out_over(const bagl_element_t* e) {
+  return NULL;
+}
+ unsigned int ui_settings_back_callback(const bagl_element_t* e) {
+  // go back to idle
+  ui_idle();
+  return 0;
+}
+ const bagl_element_t ui_settings_blue[] = {
+  // type                               userid    x    y   w    h  str rad fill      fg        bg      fid iid  txt   touchparams...       ]
+  {{BAGL_RECTANGLE, 0x00,   0,  68, 320, 413, 0, 0, BAGL_FILL, COLOR_BG_1, 0x000000, 0, 0   }, NULL, 0, 0, 0, NULL, NULL, NULL },
+   // erase screen (only under the status bar)
+  {{BAGL_RECTANGLE, 0x00,   0,  20, 320,  48, 0, 0, BAGL_FILL, COLOR_APP, COLOR_APP, 0, 0   }, NULL, 0, 0, 0, NULL, NULL, NULL},
+   /// TOP STATUS BAR
+  {{BAGL_LABELINE, 0x00,   0,  45, 320,  30, 0, 0, BAGL_FILL, 0xFFFFFF, COLOR_APP, BAGL_FONT_OPEN_SANS_SEMIBOLD_10_13PX|BAGL_FONT_ALIGNMENT_CENTER, 0   }, "SETTINGS", 0, 0, 0, NULL, NULL, NULL},
+   {{BAGL_RECTANGLE | BAGL_FLAG_TOUCHABLE, 0x00,   0,  19,  50,  44, 0, 0, BAGL_FILL, COLOR_APP, COLOR_APP_LIGHT, BAGL_FONT_SYMBOLS_0|BAGL_FONT_ALIGNMENT_CENTER|BAGL_FONT_ALIGNMENT_MIDDLE, 0 }, BAGL_FONT_SYMBOLS_0_LEFT, 0, COLOR_APP, 0xFFFFFF, ui_settings_back_callback, NULL, NULL},
+  //{{BAGL_RECTANGLE | BAGL_FLAG_TOUCHABLE, 0x00, 264,  19,  56,  44, 0, 0, BAGL_FILL, COLOR_APP, COLOR_APP_LIGHT, BAGL_FONT_SYMBOLS_0|BAGL_FONT_ALIGNMENT_CENTER|BAGL_FONT_ALIGNMENT_MIDDLE, 0 }, BAGL_FONT_SYMBOLS_0_DASHBOARD, 0, COLOR_APP, 0xFFFFFF, io_seproxyhal_touch_exit, NULL, NULL},
+   {{BAGL_LABELINE, 0x00,  30, 105, 160,  30, 0, 0, BAGL_FILL, 0x000000, COLOR_BG_1, BAGL_FONT_OPEN_SANS_REGULAR_10_13PX, 0   }, "Privacy restriction", 0, 0, 0, NULL, NULL, NULL},
+  {{BAGL_LABELINE, 0x00,  30, 126, 260,  30, 0, 0, BAGL_FILL, 0x999999, COLOR_BG_1, BAGL_FONT_OPEN_SANS_REGULAR_8_11PX, 0   }, "Export public keys only after user approval", 0, 0, 0, NULL, NULL, NULL},
+  {{BAGL_NONE   | BAGL_FLAG_TOUCHABLE, 0x00,   0,  78, 320,  68, 0, 0, BAGL_FILL, 0xFFFFFF, 0x000000, 0 , 0   }, NULL, 0, 0xEEEEEE, 0x000000, ui_settings_blue_toggle_pubKeyRequestRestriction, ui_settings_out_over, ui_settings_out_over },
+   {{BAGL_ICON, 0x01, 258,  98,  32,  18, 0, 0, BAGL_FILL, 0x000000, COLOR_BG_1, 0, 0   }, NULL, 0, 0, 0, NULL, NULL, NULL}
+};
+ const bagl_element_t * ui_settings_blue_prepro(const bagl_element_t * e) {
+  copy_element_and_map_coin_colors(e);
+  // none elements are skipped
+  if ((e->component.type&(~BAGL_FLAG_TOUCHABLE)) == BAGL_NONE) {
+    return 0;
+  }
+  // swap icon buffer to be displayed depending on if corresponding setting is enabled or not.
+  if (e->component.userid) {
+    switch(e->component.userid) {
+      case 0x01:
+        // swap icon content
+        if (N_btchip.pubKeyRequestRestriction) {
+          tmp_element.text = &C_blue_icon_toggle_set;
+        }
+        else {
+          tmp_element.text = &C_blue_icon_toggle_reset;
+        }
+        break;
+    }
+  }
+  return &tmp_element;
+}
+
+unsigned int ui_settings_blue_button(unsigned int button_mask, unsigned int button_mask_counter) {
+  return 0;  
+}
+
 #endif // #if defined(TARGET_BLUE)
 
 #if defined(TARGET_NANOS)
 
 const ux_menu_entry_t menu_main[];
+const ux_menu_entry_t menu_settings[];
+
+// change the setting
+void menu_settings_pubKeyRequestRestriction_change(unsigned int enabled) {
+    nvm_write((void *)&N_btchip.pubKeyRequestRestriction, &enabled, 1);
+    // go back to the menu entry
+    UX_MENU_DISPLAY(0, menu_main, NULL);
+}
+ const ux_menu_entry_t menu_settings_pubKeyRequestRestriction[] = {
+  {NULL, menu_settings_pubKeyRequestRestriction_change, 0, NULL, "Unrestricted", NULL, 0, 0},
+  {NULL, menu_settings_pubKeyRequestRestriction_change, 1, NULL, "Restricted", NULL, 0, 0},
+  UX_MENU_END
+};
+ const ux_menu_entry_t menu_settings[] = {
+    {menu_settings_pubKeyRequestRestriction, NULL, 0, NULL, "Public keys", "requests", 0, 0},
+    {menu_main, NULL, 1, &C_nanos_icon_back, "Back", NULL, 61, 40},
+    UX_MENU_END};
 
 const ux_menu_entry_t menu_about[] = {
     {NULL, NULL, 0, NULL, "Version", APPVERSION, 0, 0},
@@ -257,6 +337,7 @@ const ux_menu_entry_t menu_main[] = {
     //{NULL, NULL, 0, &NAME3(C_nanos_badge_, COINID, ), "Use wallet to", "view
     // accounts", 33, 12},
     {NULL, NULL, 0, NULL, "Use wallet to", "view accounts", 0, 0},
+    {menu_settings, NULL, 0, NULL, "Settings", NULL, 0, 0},
     {menu_about, NULL, 0, NULL, "About", NULL, 0, 0},
     {NULL, os_sched_exit, 0, &C_nanos_icon_dashboard, "Quit app", NULL, 50, 29},
     UX_MENU_END};
@@ -1034,6 +1115,164 @@ const bagl_element_t ui_display_address_blue[] = {
      NULL},
 };
 
+
+const bagl_element_t ui_display_token_blue[] = {
+    {{BAGL_RECTANGLE, 0x00, 0, 68, 320, 413, 0, 0, BAGL_FILL, COLOR_BG_1,
+      0x000000, 0, 0},
+     NULL,
+     0,
+     0,
+     0,
+     NULL,
+     NULL,
+     NULL},
+     // erase screen (only under the status bar)
+    {{BAGL_RECTANGLE, 0x00, 0, 20, 320, 48, 0, 0, BAGL_FILL, COLOR_APP,
+      COLOR_APP, 0, 0},
+     NULL,
+     0,
+     0,
+     0,
+     NULL,
+     NULL,
+     NULL},
+     /// TOP STATUS BAR
+    {{BAGL_LABELINE, 0x00, 0, 45, 320, 30, 0, 0, BAGL_FILL, 0xFFFFFF, COLOR_APP,
+      BAGL_FONT_OPEN_SANS_SEMIBOLD_10_13PX | BAGL_FONT_ALIGNMENT_CENTER, 0},
+     "CHECK IF TOKENS ARE IDENTICAL",
+     0,
+     0,
+     0,
+     NULL,
+     NULL,
+     NULL},
+     //{{BAGL_RECTANGLE | BAGL_FLAG_TOUCHABLE, 0x00, 264,  19,  56,  44, 0, 0,
+    //BAGL_FILL, COLOR_APP, COLOR_APP_LIGHT,
+    //BAGL_FONT_SYMBOLS_0|BAGL_FONT_ALIGNMENT_CENTER|BAGL_FONT_ALIGNMENT_MIDDLE,
+    //0 }, BAGL_FONT_SYMBOLS_0_DASHBOARD, 0, COLOR_APP, 0xFFFFFF,
+    //io_seproxyhal_touch_exit, NULL, NULL},
+     {{BAGL_LABELINE, 0x00, 30, 185, 260, 30, 0, 0, BAGL_FILL, 0x000000,
+      COLOR_BG_1, BAGL_FONT_OPEN_SANS_SEMIBOLD_11_16PX | BAGL_FONT_ALIGNMENT_CENTER, 0},
+     "Token:",
+     0,
+     0,
+     0,
+     NULL,
+     NULL,
+     NULL},
+     {{BAGL_LABELINE, 0x10, 30, 220, 260, 30, 0, 0, BAGL_FILL, 0x000000,
+      COLOR_BG_1, BAGL_FONT_OPEN_SANS_REGULAR_22_30PX | BAGL_FONT_ALIGNMENT_CENTER, 0},
+     vars.tmpqr.addressSummary,
+     0,
+     0,
+     0,
+     NULL,
+     NULL,
+     NULL},
+     {{BAGL_RECTANGLE | BAGL_FLAG_TOUCHABLE, 0x00, 40, 414, 115, 36, 0, 18,
+      BAGL_FILL, 0xCCCCCC, COLOR_BG_1,
+      BAGL_FONT_OPEN_SANS_REGULAR_11_14PX | BAGL_FONT_ALIGNMENT_CENTER |
+          BAGL_FONT_ALIGNMENT_MIDDLE,
+      0},
+     "REJECT",
+     0,
+     0xB7B7B7,
+     COLOR_BG_1,
+     io_seproxyhal_touch_display_cancel,
+     NULL,
+     NULL},
+    {{BAGL_RECTANGLE | BAGL_FLAG_TOUCHABLE, 0x00, 165, 414, 115, 36, 0, 18,
+      BAGL_FILL, 0x41ccb4, COLOR_BG_1,
+      BAGL_FONT_OPEN_SANS_REGULAR_11_14PX | BAGL_FONT_ALIGNMENT_CENTER |
+          BAGL_FONT_ALIGNMENT_MIDDLE,
+      0},
+     "APPROVE",
+     0,
+     0x3ab7a2,
+     COLOR_BG_1,
+     io_seproxyhal_touch_display_ok,
+     NULL,
+     NULL},
+};
+ const bagl_element_t ui_request_pubkey_approval_blue[] = {
+    {{BAGL_RECTANGLE, 0x00, 0, 68, 320, 413, 0, 0, BAGL_FILL, COLOR_BG_1,
+      0x000000, 0, 0},
+     NULL,
+     0,
+     0,
+     0,
+     NULL,
+     NULL,
+     NULL},
+     // erase screen (only under the status bar)
+    {{BAGL_RECTANGLE, 0x00, 0, 20, 320, 48, 0, 0, BAGL_FILL, COLOR_APP,
+      COLOR_APP, 0, 0},
+     NULL,
+     0,
+     0,
+     0,
+     NULL,
+     NULL,
+     NULL},
+     /// TOP STATUS BAR
+    {{BAGL_LABELINE, 0x00, 0, 45, 320, 30, 0, 0, BAGL_FILL, 0xFFFFFF, COLOR_APP,
+      BAGL_FONT_OPEN_SANS_SEMIBOLD_10_13PX | BAGL_FONT_ALIGNMENT_CENTER, 0},
+     "PUBLIC KEY EXPORT",
+     0,
+     0,
+     0,
+     NULL,
+     NULL,
+     NULL},
+     //{{BAGL_RECTANGLE | BAGL_FLAG_TOUCHABLE, 0x00, 264,  19,  56,  44, 0, 0,
+    //BAGL_FILL, COLOR_APP, COLOR_APP_LIGHT,
+    //BAGL_FONT_SYMBOLS_0|BAGL_FONT_ALIGNMENT_CENTER|BAGL_FONT_ALIGNMENT_MIDDLE,
+    //0 }, BAGL_FONT_SYMBOLS_0_DASHBOARD, 0, COLOR_APP, 0xFFFFFF,
+    //io_seproxyhal_touch_exit, NULL, NULL},
+     {{BAGL_LABELINE, 0x00, 0, 160, 320, 30, 0, 0, BAGL_FILL, 0x000000,
+      COLOR_BG_1, BAGL_FONT_OPEN_SANS_SEMIBOLD_11_16PX | BAGL_FONT_ALIGNMENT_CENTER, 0},
+     "A remote app is requesting access ",
+     0,
+     0,
+     0,
+     NULL,
+     NULL,
+     NULL},
+     {{BAGL_LABELINE, 0x00, 0, 180, 320, 30, 0, 0, BAGL_FILL, 0x000000,
+      COLOR_BG_1, BAGL_FONT_OPEN_SANS_SEMIBOLD_11_16PX | BAGL_FONT_ALIGNMENT_CENTER, 0},
+     "to your public keys",
+     0,
+     0,
+     0,
+     NULL,
+     NULL,
+     NULL},
+     {{BAGL_RECTANGLE | BAGL_FLAG_TOUCHABLE, 0x00, 40, 414, 115, 36, 0, 18,
+      BAGL_FILL, 0xCCCCCC, COLOR_BG_1,
+      BAGL_FONT_OPEN_SANS_REGULAR_11_14PX | BAGL_FONT_ALIGNMENT_CENTER |
+          BAGL_FONT_ALIGNMENT_MIDDLE,
+      0},
+     "REJECT",
+     0,
+     0xB7B7B7,
+     COLOR_BG_1,
+     io_seproxyhal_touch_display_cancel,
+     NULL,
+     NULL},
+    {{BAGL_RECTANGLE | BAGL_FLAG_TOUCHABLE, 0x00, 165, 414, 115, 36, 0, 18,
+      BAGL_FILL, 0x41ccb4, COLOR_BG_1,
+      BAGL_FONT_OPEN_SANS_REGULAR_11_14PX | BAGL_FONT_ALIGNMENT_CENTER |
+          BAGL_FONT_ALIGNMENT_MIDDLE,
+      0},
+     "APPROVE",
+     0,
+     0x3ab7a2,
+     COLOR_BG_1,
+     io_seproxyhal_touch_display_ok,
+     NULL,
+     NULL},
+};
+
 unsigned int ui_display_address_blue_prepro(const bagl_element_t *element) {
     bagl_icon_details_t *icon_details = &vars.tmpqr.icon_details;
     bagl_element_t *icon_component = element;
@@ -1112,10 +1351,23 @@ unsigned int ui_display_address_blue_prepro(const bagl_element_t *element) {
     }
     return &tmp_element;
 }
+
 unsigned int ui_display_address_blue_button(unsigned int button_mask,
                                             unsigned int button_mask_counter) {
     return 0;
 }
+
+unsigned int ui_display_token_blue_button(unsigned int button_mask,
+                                            unsigned int button_mask_counter)
+{
+    return 0;
+}
+ unsigned int ui_request_pubkey_approval_blue_button(unsigned int button_mask,
+                                            unsigned int button_mask_counter)
+{
+    return 0;
+}
+
 #endif // #if defined(TARGET_BLUE)
 
 #if defined(TARGET_NANOS)
@@ -1199,6 +1451,111 @@ const bagl_element_t ui_display_address_nanos[] = {
     //NULL, NULL },
 };
 
+const bagl_element_t ui_display_token_nanos[] = {
+    // type                               userid    x    y   w    h  str rad
+    // fill      fg        bg      fid iid  txt   touchparams...       ]
+    {{BAGL_RECTANGLE, 0x00, 0, 0, 128, 32, 0, 0, BAGL_FILL, 0x000000, 0xFFFFFF,
+      0, 0},
+     NULL,
+     0,
+     0,
+     0,
+     NULL,
+     NULL,
+     NULL},
+     {{BAGL_ICON, 0x00, 3, 12, 7, 7, 0, 0, 0, 0xFFFFFF, 0x000000, 0,
+      BAGL_GLYPH_ICON_CROSS},
+     NULL,
+     0,
+     0,
+     0,
+     NULL,
+     NULL,
+     NULL},
+    {{BAGL_ICON, 0x00, 117, 13, 8, 6, 0, 0, 0, 0xFFFFFF, 0x000000, 0,
+      BAGL_GLYPH_ICON_CHECK},
+     NULL,
+     0,
+     0,
+     0,
+     NULL,
+     NULL,
+     NULL},
+     //{{BAGL_ICON                           , 0x01,  21,   9,  14,  14, 0, 0, 0
+    //, 0xFFFFFF, 0x000000, 0, BAGL_GLYPH_ICON_TRANSACTION_BADGE  }, NULL, 0, 0,
+    //0, NULL, NULL, NULL },
+    {{BAGL_LABELINE, 0x01, 0, 12, 128, 12, 0, 0, 0, 0xFFFFFF, 0x000000,
+      BAGL_FONT_OPEN_SANS_EXTRABOLD_11px | BAGL_FONT_ALIGNMENT_CENTER, 0},
+     "Confirm token",
+     0,
+     0,
+     0,
+     NULL,
+     NULL,
+     NULL},
+    {{BAGL_LABELINE, 0x01, 0, 26, 128, 12, 0, 0, 0, 0xFFFFFF, 0x000000,
+      BAGL_FONT_OPEN_SANS_EXTRABOLD_11px | BAGL_FONT_ALIGNMENT_CENTER, 0},
+     G_io_apdu_buffer + 199,
+     0,
+     0,
+     0,
+     NULL,
+     NULL,
+     NULL},
+};
+ const bagl_element_t ui_request_pubkey_approval_nanos[] = {
+    // type                               userid    x    y   w    h  str rad
+    // fill      fg        bg      fid iid  txt   touchparams...       ]
+    {{BAGL_RECTANGLE, 0x00, 0, 0, 128, 32, 0, 0, BAGL_FILL, 0x000000, 0xFFFFFF,
+      0, 0},
+     NULL,
+     0,
+     0,
+     0,
+     NULL,
+     NULL,
+     NULL},
+     {{BAGL_ICON, 0x00, 3, 12, 7, 7, 0, 0, 0, 0xFFFFFF, 0x000000, 0,
+      BAGL_GLYPH_ICON_CROSS},
+     NULL,
+     0,
+     0,
+     0,
+     NULL,
+     NULL,
+     NULL},
+    {{BAGL_ICON, 0x00, 117, 13, 8, 6, 0, 0, 0, 0xFFFFFF, 0x000000, 0,
+      BAGL_GLYPH_ICON_CHECK},
+     NULL,
+     0,
+     0,
+     0,
+     NULL,
+     NULL,
+     NULL},
+     //{{BAGL_ICON                           , 0x01,  21,   9,  14,  14, 0, 0, 0
+    //, 0xFFFFFF, 0x000000, 0, BAGL_GLYPH_ICON_TRANSACTION_BADGE  }, NULL, 0, 0,
+    //0, NULL, NULL, NULL },
+    {{BAGL_LABELINE, 0x01, 0, 12, 128, 12, 0, 0, 0, 0xFFFFFF, 0x000000,
+      BAGL_FONT_OPEN_SANS_EXTRABOLD_11px | BAGL_FONT_ALIGNMENT_CENTER, 0},
+     "Export",
+     0,
+     0,
+     0,
+     NULL,
+     NULL,
+     NULL},
+    {{BAGL_LABELINE, 0x01, 0, 26, 128, 12, 0, 0, 0, 0xFFFFFF, 0x000000,
+      BAGL_FONT_OPEN_SANS_EXTRABOLD_11px | BAGL_FONT_ALIGNMENT_CENTER, 0},
+     "public key?",
+     0,
+     0,
+     0,
+     NULL,
+     NULL,
+     NULL},
+};
+
 unsigned int ui_display_address_nanos_prepro(const bagl_element_t *element) {
     if (element->component.userid > 0) {
         unsigned int display = (ux_step == element->component.userid - 1);
@@ -1219,6 +1576,10 @@ unsigned int ui_display_address_nanos_prepro(const bagl_element_t *element) {
 }
 
 unsigned int ui_display_address_nanos_button(unsigned int button_mask,
+                                             unsigned int button_mask_counter);
+unsigned int ui_display_token_nanos_button(unsigned int button_mask,
+                                             unsigned int button_mask_counter);
+unsigned int ui_request_pubkey_approval_nanos_button(unsigned int button_mask,
                                              unsigned int button_mask_counter);
 
 const bagl_element_t ui_verify_nanos[] = {
@@ -1688,6 +2049,11 @@ void ui_idle(void) {
 
 #ifdef TARGET_BLUE
 
+unsigned int io_seproxyhal_touch_settings(const bagl_element_t *e) {
+  UX_DISPLAY(ui_settings_blue, ui_settings_blue_prepro);
+  return 0; // do not redraw button, screen has switched
+}
+
 unsigned int io_seproxyhal_touch_exit(const bagl_element_t *e) {
     // go back to the home screen
     os_sched_exit(0);
@@ -1813,6 +2179,35 @@ unsigned int ui_display_address_nanos_button(unsigned int button_mask,
         break;
 
     case BUTTON_EVT_RELEASED | BUTTON_RIGHT:
+        io_seproxyhal_touch_display_ok(NULL);
+        break;
+    }
+    return 0;
+}
+
+unsigned int ui_display_token_nanos_button(unsigned int button_mask,
+                                             unsigned int button_mask_counter)
+{
+    switch (button_mask)
+    {
+    case BUTTON_EVT_RELEASED | BUTTON_LEFT:
+        io_seproxyhal_touch_display_cancel(NULL);
+        break;
+     case BUTTON_EVT_RELEASED | BUTTON_RIGHT:
+        io_seproxyhal_touch_display_ok(NULL);
+        break;
+    }
+    return 0;
+}
+ unsigned int ui_request_pubkey_approval_nanos_button(unsigned int button_mask,
+                                             unsigned int button_mask_counter)
+{
+    switch (button_mask)
+    {
+    case BUTTON_EVT_RELEASED | BUTTON_LEFT:
+        io_seproxyhal_touch_display_cancel(NULL);
+        break;
+     case BUTTON_EVT_RELEASED | BUTTON_RIGHT:
         io_seproxyhal_touch_display_ok(NULL);
         break;
     }
@@ -2458,6 +2853,36 @@ unsigned int btchip_bagl_display_public_key() {
 #endif // #if TARGET_ID
     return 1;
 }
+
+unsigned int btchip_bagl_display_token()
+{
+    // setup qrcode of the address in the apdu buffer
+    strcat(G_io_apdu_buffer + 200, " ");
+ #if defined(TARGET_BLUE)
+    
+    UX_DISPLAY(ui_display_token_blue, ui_display_address_blue_prepro);
+#elif defined(TARGET_NANOS)
+    // append and prepend a white space to the address
+    G_io_apdu_buffer[199] = ' ';
+    ux_step = 0;
+    ux_step_count = 1;
+    UX_DISPLAY(ui_display_token_nanos, NULL);
+#endif // #if TARGET_ID
+    return 1;
+}
+ unsigned int btchip_bagl_request_pubkey_approval()
+{
+ #if defined(TARGET_BLUE)
+     UX_DISPLAY(ui_request_pubkey_approval_blue, ui_display_address_blue_prepro);
+#elif defined(TARGET_NANOS)
+    // append and prepend a white space to the address
+    ux_step = 0;
+    ux_step_count = 1;
+    UX_DISPLAY(ui_request_pubkey_approval_nanos, NULL);
+#endif // #if TARGET_ID
+    return 1;
+}
+
 
 void app_exit(void) {
     BEGIN_TRY_L(exit) {


### PR DESCRIPTION
This PR adds an option disabled by default that will trigger a user validation request on the device when a call to get_wallet_pubic_key is made through U2F transport. Other means of transport such as HID are not affected.
This feature is meant to protect users from having their public keys leaked through malicious web page which would talk to unlocked Ledger device silently, using U2F transport.
Compatible wallets can also update their calls to get_wallet_public_key to request the validation of a token passed in the call on the device, this token being also displayed on the desktop wallet. This feature counters potential race condition where a legit wallet would be running concurrently with a malicious page/script. 

Here is the matrix of behaviors, depending on what is supported in the device/desktop wallet. There is no incompatibility with old desktop wallets, but wallets supporting the new token display might want to take in account the legacy apps.
 
![get_pub_key update 1](https://user-images.githubusercontent.com/10632523/48210947-b5c57f00-e378-11e8-8eb7-25303d18bc4d.png)

