### PR TITLE
Fixes for base 58 encoding and decoding

### DIFF
--- a/include/btchip_base58.h
+++ b/include/btchip_base58.h
@@ -19,9 +19,10 @@
 
 #define BTCHIP_BASE58_H
 
-unsigned char btchip_decode_base58(unsigned char WIDE *in, unsigned char length,
-                                   unsigned char *out, unsigned char maxoutlen);
-unsigned char btchip_encode_base58(unsigned char WIDE *in, unsigned char length,
-                                   unsigned char *out, unsigned char maxoutlen);
+int btchip_decode_base58(const char WIDE *in, unsigned char length,
+                         unsigned char *out, size_t *outlen);
+
+int btchip_encode_base58(const unsigned char WIDE *in, size_t length,
+                         unsigned char *out, size_t *outlen);
 
 #endif

--- a/include/btchip_base58.h
+++ b/include/btchip_base58.h
@@ -19,7 +19,9 @@
 
 #define BTCHIP_BASE58_H
 
-int btchip_decode_base58(const char WIDE *in, unsigned char length,
+#include <stdlib.h>
+
+int btchip_decode_base58(const char WIDE *in, size_t length,
                          unsigned char *out, size_t *outlen);
 
 int btchip_encode_base58(const unsigned char WIDE *in, size_t length,

--- a/src/btchip_base58.c
+++ b/src/btchip_base58.c
@@ -17,107 +17,118 @@
 
 #include "btchip_internal.h"
 
-unsigned char btchip_decode_base58(unsigned char WIDE *in, unsigned char length,
-                                   unsigned char *out,
-                                   unsigned char maxoutlen) {
-    unsigned char tmp[164];
-    unsigned char buffer[164];
-    unsigned char i;
-    unsigned char j;
-    unsigned char startAt;
-    unsigned char zeroCount = 0;
-    if (length > sizeof(tmp)) {
-        THROW(INVALID_PARAMETER);
+#define MAX_DEC_INPUT_SIZE 164
+#define MAX_ENC_INPUT_SIZE 120
+
+int btchip_decode_base58(const char WIDE *in, unsigned char length,
+                         unsigned char *out, size_t *outlen) {
+  unsigned char tmp[MAX_DEC_INPUT_SIZE];
+  unsigned char buffer[MAX_DEC_INPUT_SIZE] = {0};
+  unsigned char i;
+  unsigned char j;
+  unsigned char startAt;
+  unsigned char zeroCount = 0;
+  if (length > MAX_DEC_INPUT_SIZE) {
+    return -1;
+  }
+  memmove(tmp, in, length);
+  L_DEBUG_BUF(("To decode\n", tmp, length));
+  for (i = 0; i < length; i++) {
+    if (in[i] >= sizeof(BASE58TABLE)) {
+      return -1;
     }
-    os_memmove(tmp, in, length);
-    L_DEBUG_BUF(("To decode\n", tmp, length));
-    for (i = 0; i < length; i++) {
-        if (in[i] > 128) {
-            THROW(EXCEPTION);
-        }
-        tmp[i] = BASE58TABLE[in[i]];
-        if (tmp[i] == 0xff) {
-            THROW(EXCEPTION);
-        }
+    tmp[i] = BASE58TABLE[(int)in[i]];
+    if (tmp[i] == 0xff) {
+      return -1;
     }
-    while ((zeroCount < length) && (tmp[zeroCount] == 0)) {
-        ++zeroCount;
+  }
+  while ((zeroCount < length) && (tmp[zeroCount] == 0)) {
+    ++zeroCount;
+  }
+  j = length;
+  startAt = zeroCount;
+  while (startAt < length) {
+    unsigned short remainder = 0;
+    unsigned char divLoop;
+    for (divLoop = startAt; divLoop < length; divLoop++) {
+      unsigned short digit256 = (unsigned short)(tmp[divLoop] & 0xff);
+      unsigned short tmpDiv = remainder * 58 + digit256;
+      tmp[divLoop] = (unsigned char)(tmpDiv / 256);
+      remainder = (tmpDiv % 256);
     }
-    j = length;
-    startAt = zeroCount;
-    while (startAt < length) {
-        unsigned short remainder = 0;
-        unsigned char divLoop;
-        for (divLoop = startAt; divLoop < length; divLoop++) {
-            unsigned short digit256 = (unsigned short)(tmp[divLoop] & 0xff);
-            unsigned short tmpDiv = remainder * 58 + digit256;
-            tmp[divLoop] = (unsigned char)(tmpDiv / 256);
-            remainder = (tmpDiv % 256);
-        }
-        if (tmp[startAt] == 0) {
-            ++startAt;
-        }
-        buffer[--j] = (unsigned char)remainder;
+    if (tmp[startAt] == 0) {
+      ++startAt;
     }
-    while ((j < length) && (buffer[j] == 0)) {
-        ++j;
-    }
-    length = length - (j - zeroCount);
-    if (maxoutlen < length) {
-        L_DEBUG_APP(("Decode overflow %d %d\n", length, maxoutlen));
-        THROW(EXCEPTION_OVERFLOW);
-    }
-    os_memmove(out, buffer + j - zeroCount, length);
-    L_DEBUG_BUF(("Decoded\n", out, length));
-    return length;
+    buffer[--j] = (unsigned char)remainder;
+  }
+  while ((j < length) && (buffer[j] == 0)) {
+    ++j;
+  }
+  length = length - (j - zeroCount);
+  if (*outlen < length) {
+    L_DEBUG_APP(("Decode overflow %d %d\n", length, *outlen));
+    return -1;
+  }
+
+  memmove(out, buffer + j - zeroCount, length);
+  L_DEBUG_BUF(("Decoded\n", out, length));
+  *outlen = length;
+  return 0;
 }
 
-unsigned char btchip_encode_base58(unsigned char WIDE *in, unsigned char length,
-                                   unsigned char *out,
-                                   unsigned char maxoutlen) {
-    unsigned char tmp[164];
-    unsigned char buffer[164];
-    unsigned char j;
-    unsigned char startAt;
-    unsigned char zeroCount = 0;
-    if (length > sizeof(tmp)) {
-        THROW(INVALID_PARAMETER);
+int btchip_encode_base58(const unsigned char WIDE *in, size_t length,
+                         unsigned char *out, size_t *outlen) {
+  unsigned char buffer[MAX_ENC_INPUT_SIZE * 138 / 100 + 1] = {0};
+  size_t i = 0, j;
+  size_t startAt, stopAt;
+  size_t zeroCount = 0;
+  size_t outputSize;
+
+  if (length > MAX_ENC_INPUT_SIZE) {
+    return -1;
+  }
+
+  L_DEBUG_APP(("Length to encode %d\n", length));
+  L_DEBUG_BUF(("To encode\n", in, length));
+
+  while ((zeroCount < length) && (in[zeroCount] == 0)) {
+    ++zeroCount;
+  }
+
+  outputSize = (length - zeroCount) * 138 / 100 + 1;
+  stopAt = outputSize - 1;
+  for (startAt = zeroCount; startAt < length; startAt++) {
+    int carry = in[startAt];
+    for (j = outputSize - 1; j >= 0; j--) {
+      carry += 256 * buffer[j];
+      buffer[j] = carry % 58;
+      carry /= 58;
+
+      if (j < stopAt - 1 && carry == 0) {
+        break;
+      }
     }
-    os_memmove(tmp, in, length);
-    L_DEBUG_APP(("Length to encode %d\n", length));
-    L_DEBUG_BUF(("To encode\n", tmp, length));
-    while ((zeroCount < length) && (tmp[zeroCount] == 0)) {
-        ++zeroCount;
-    }
-    j = 2 * length;
-    startAt = zeroCount;
-    while (startAt < length) {
-        unsigned short remainder = 0;
-        unsigned char divLoop;
-        for (divLoop = startAt; divLoop < length; divLoop++) {
-            unsigned short digit256 = (unsigned short)(tmp[divLoop] & 0xff);
-            unsigned short tmpDiv = remainder * 256 + digit256;
-            tmp[divLoop] = (unsigned char)(tmpDiv / 58);
-            remainder = (tmpDiv % 58);
-        }
-        if (tmp[startAt] == 0) {
-            ++startAt;
-        }
-        buffer[--j] = (unsigned char)BASE58ALPHABET[remainder];
-    }
-    while ((j < (2 * length)) && (buffer[j] == BASE58ALPHABET[0])) {
-        ++j;
-    }
-    while (zeroCount-- > 0) {
-        buffer[--j] = BASE58ALPHABET[0];
-    }
-    length = 2 * length - j;
-    if (maxoutlen < length) {
-        L_DEBUG_APP(("Encode overflow %d %d\n", length, maxoutlen));
-        THROW(EXCEPTION_OVERFLOW);
-    }
-    os_memmove(out, (buffer + j), length);
-    L_DEBUG_APP(("Length encoded %d\n", length));
-    L_DEBUG_BUF(("Encoded\n", out, length));
-    return length;
+    stopAt = j;
+  }
+
+  j = 0;
+  while (j < outputSize && buffer[j] == 0) {
+    j += 1;
+  }
+
+  if (*outlen < zeroCount + outputSize - j) {
+    *outlen = zeroCount + outputSize - j;
+    return -1;
+  }
+
+  os_memset(out, BASE58ALPHABET[0], zeroCount);
+
+  i = zeroCount;
+  while (j < outputSize) {
+    out[i++] = BASE58ALPHABET[buffer[j++]];
+  }
+  *outlen = i;
+  L_DEBUG_APP(("Length encoded %d\n", i));
+  L_DEBUG_BUF(("Encoded\n", out, i));
+  return 0;
 }

--- a/src/btchip_base58.c
+++ b/src/btchip_base58.c
@@ -20,7 +20,7 @@
 #define MAX_DEC_INPUT_SIZE 164
 #define MAX_ENC_INPUT_SIZE 120
 
-int btchip_decode_base58(const char WIDE *in, unsigned char length,
+int btchip_decode_base58(const char WIDE *in, size_t length,
                          unsigned char *out, size_t *outlen) {
   unsigned char tmp[MAX_DEC_INPUT_SIZE];
   unsigned char buffer[MAX_DEC_INPUT_SIZE] = {0};
@@ -31,7 +31,7 @@ int btchip_decode_base58(const char WIDE *in, unsigned char length,
   if (length > MAX_DEC_INPUT_SIZE) {
     return -1;
   }
-  memmove(tmp, in, length);
+  os_memmove(tmp, in, length);
   L_DEBUG_BUF(("To decode\n", tmp, length));
   for (i = 0; i < length; i++) {
     if (in[i] >= sizeof(BASE58TABLE)) {
@@ -70,7 +70,7 @@ int btchip_decode_base58(const char WIDE *in, unsigned char length,
     return -1;
   }
 
-  memmove(out, buffer + j - zeroCount, length);
+  os_memmove(out, buffer + j - zeroCount, length);
   L_DEBUG_BUF(("Decoded\n", out, length));
   *outlen = length;
   return 0;
@@ -99,7 +99,7 @@ int btchip_encode_base58(const unsigned char WIDE *in, size_t length,
   stopAt = outputSize - 1;
   for (startAt = zeroCount; startAt < length; startAt++) {
     int carry = in[startAt];
-    for (j = outputSize - 1; j >= 0; j--) {
+    for (j = outputSize - 1; (int)j >= 0; j--) {
       carry += 256 * buffer[j];
       buffer[j] = carry % 58;
       carry /= 58;


### PR DESCRIPTION
This PR fixes a OOB read in the base58 decoding function and a OBB write in the encoding function.

The encoding function has been rewritten so that it uses much less stack. Finally, a small bug has been fixed in the decoding function: buffers with several leading 1s were not properly decoded.

The prototypes of the function have been modified to make tests easier. Return value must be checked by the caller as they do not throw exceptions anymore.