### PR TITLE
Allow Ledger to sign Komodo reward claim transactions

### DIFF
--- a/src/btchip_transaction.c
+++ b/src/btchip_transaction.c
@@ -67,6 +67,13 @@ unsigned char transaction_amount_sub_be(unsigned char *target,
         }
         target[8 - 1 - i] = (unsigned char)(tmpA - tmpB);
     }
+
+    // allow device to sign Komodo reward claim transactions
+    // (the outputs are intentionally larger than the inputs)
+    if (G_coin_config->kind == COIN_KIND_KOMODO) {
+      borrow = 0;
+    }
+
     return borrow;
 }
 


### PR DESCRIPTION
Resolves https://github.com/LedgerHQ/ledger-app-btc/issues/60

In Komodo you can claim rewards (essentially interest) based on the age of your UTXOs. This mints the new coins in the claim transaction which means the output amount is expected to be larger than the input amount.

Asking the Ledger to sign a Komodo reward claim transaction will result in an error because it won't allow a transaction to have a larger output amount than an input amount.

This PR ignores that check for Komodo. This simple change is wrapped in `G_coin_config->kind == COIN_KIND_KOMODO` so it will not affect any other currencies. It also will not break the way Komodo currently works in Ledger Live or other existing Komodo Ledger apps. Normal transactions will continue to work as normal, but now reward claim transactions can be signed too.

Let me know if this is ok or if you require any changes :)