### PR TITLE
Add missing header

### DIFF
--- a/include/btchip_context.h
+++ b/include/btchip_context.h
@@ -20,6 +20,7 @@
 #define BTCHIP_CONTEXT_H
 
 #include "os.h"
+#include "cx.h"
 #include "btchip_secure_value.h"
 #include "btchip_filesystem_tx.h"
 


### PR DESCRIPTION
Include cx.h in btchip_context.h, required for `cx_sha256_t` and `cx_blake2b_t` types.