### PR TITLE
Always use standard formatters for snprintf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,7 @@ endif
 CC       := $(CLANGPATH)clang
 
 #CFLAGS   += -O0
-CFLAGS   += -O3 -Os -Wno-format-invalid-specifier
+CFLAGS   += -O3 -Os
 AS     := $(GCCPATH)arm-none-eabi-gcc
 
 LD       := $(GCCPATH)arm-none-eabi-gcc

--- a/src/main.c
+++ b/src/main.c
@@ -981,7 +981,10 @@ uint8_t prepare_message_signature() {
     cx_hash(&btchip_context_D.transactionHashAuthorization.header, CX_LAST,
             (uint8_t*)vars.tmp.fullAmount, 0, buffer, 32);
 
-    snprintf(vars.tmp.fullAddress, sizeof(vars.tmp.fullAddress), "%.*H", buffer);
+    for (size_t i = 0; i < sizeof(buffer); i++) {
+        snprintf(vars.tmp.fullAddress + 2 * i, sizeof(vars.tmp.fullAddress) - 2 * i,
+                 "%02X", buffer[i]);
+    }
     return 1;
 }
 


### PR DESCRIPTION
The single call to `snprintf` with our custom formatter was incorrectly used. Using a standard formatter does not increase code
size, and prevents from disabling format string warnings during compilation.