### PR TITLE
allow signing of peercoin coinstake transactions

### DIFF
--- a/include/btchip_helpers.h
+++ b/include/btchip_helpers.h
@@ -39,6 +39,7 @@ unsigned char btchip_output_script_is_op_create(unsigned char *buffer,
                                                 size_t size);
 unsigned char btchip_output_script_is_op_call(unsigned char *buffer,
                                                 size_t size);
+unsigned char btchip_output_script_is_empty(unsigned char *buffer);
 
 void btchip_sleep16(unsigned short delay);
 void btchip_sleep32(unsigned long int delayEach, unsigned long int delayRepeat);

--- a/src/btchip_helpers.c
+++ b/src/btchip_helpers.c
@@ -149,6 +149,10 @@ unsigned char btchip_output_script_is_op_call(unsigned char *buffer,
     return output_script_is_op_create_or_call(buffer, size, 0xC2);
 }
 
+unsigned char btchip_output_script_is_empty(unsigned char *buffer) {
+    return buffer[0] == 0;
+}
+
 unsigned char btchip_rng_u8_modulo(unsigned char modulo) {
     unsigned int rng_max = 256 % modulo;
     unsigned int rng_limit = 256 - rng_max;

--- a/src/main.c
+++ b/src/main.c
@@ -812,7 +812,7 @@ uint8_t prepare_fees() {
         borrow = transaction_amount_sub_be(
                 fees, btchip_context_D.transactionContext.transactionAmount,
                 btchip_context_D.totalOutputAmount);
-        if (borrow && G_coin_config->kind == COIN_KIND_KOMODO) {
+        if (borrow && (G_coin_config->kind == COIN_KIND_KOMODO || G_coin_config->kind == COIN_KIND_PEERCOIN)) {
             os_memmove(vars.tmp.feesAmount, "REWARD", 6);
             vars.tmp.feesAmount[6] = '\0';
         }
@@ -844,6 +844,10 @@ error:
 void get_address_from_output_script(unsigned char* script, int script_size, char* out, int out_size) {
     if (btchip_output_script_is_op_return(script)) {
         strcpy(out, "OP_RETURN");
+        return;
+    }
+    if (G_coin_config->kind == COIN_KIND_PEERCOIN && btchip_output_script_is_empty(script)) {
+        strcpy(out, "COINSTAKE");
         return;
     }
     if ((G_coin_config->kind == COIN_KIND_QTUM || G_coin_config->kind == COIN_KIND_HYDRA) &&


### PR DESCRIPTION
in order to enable minting from ledger, we need to be able to sign coinstake transactions, coinstake is transaction that allows zero outputs and negative fees (called rewards)

as requested by @bigspider , recreating pull request in this repository instead of app-bitcoin-new