### PR TITLE
Fix extra values

### DIFF
--- a/src/btchip_transaction.c
+++ b/src/btchip_transaction.c
@@ -1095,6 +1095,12 @@ void transaction_parse(unsigned char parseMode) {
                     }
 
                     if (btchip_context_D.NU5Transaction) { 
+                        // We don't support sapling or orchard actions 
+                        // Only expiryHeight should remain at this point
+                        if (btchip_context_D.transactionDataRemaining != 4) {
+                            PRINTF("expiryHeight expected");
+                            goto fail;
+                        }
                         // expiryHeight
                         blake2b_256_update(&btchip_context_D.transactionHashFull.blake2b, btchip_context_D.transactionBufferPointer, 4);
                     }


### PR DESCRIPTION
Make sure no other data is accepted after transparent input/output parsing other than expiryHeight