### PR TITLE
Fix Horizen transaction output checks

### DIFF
--- a/src/btchip_helpers.c
+++ b/src/btchip_helpers.c
@@ -70,6 +70,13 @@ unsigned char btchip_output_script_is_regular(unsigned char *buffer) {
             return 1;
         }
     }
+    if ((memcmp(buffer, TRANSACTION_OUTPUT_SCRIPT_PRE,
+                       sizeof(TRANSACTION_OUTPUT_SCRIPT_PRE)) == 0) &&
+        (memcmp(buffer + sizeof(TRANSACTION_OUTPUT_SCRIPT_PRE) + 20,
+                       TRANSACTION_OUTPUT_SCRIPT_POST,
+                       sizeof(TRANSACTION_OUTPUT_SCRIPT_POST)) == 0)) {
+        return 1;
+    }
     if (G_coin_config->kind == COIN_KIND_HORIZEN) {
         if ((memcmp(buffer, ZEN_OUTPUT_SCRIPT_PRE,
                        sizeof(ZEN_OUTPUT_SCRIPT_PRE)) == 0) &&
@@ -78,33 +85,25 @@ unsigned char btchip_output_script_is_regular(unsigned char *buffer) {
                        sizeof(ZEN_OUTPUT_SCRIPT_POST)) == 0)) {
             return 1;
         }
-    } else {
-        if ((memcmp(buffer, TRANSACTION_OUTPUT_SCRIPT_PRE,
-                       sizeof(TRANSACTION_OUTPUT_SCRIPT_PRE)) == 0) &&
-            (memcmp(buffer + sizeof(TRANSACTION_OUTPUT_SCRIPT_PRE) + 20,
-                       TRANSACTION_OUTPUT_SCRIPT_POST,
-                       sizeof(TRANSACTION_OUTPUT_SCRIPT_POST)) == 0)) {
-            return 1;
-        }
     }
+
     return 0;
 }
 
 unsigned char btchip_output_script_is_p2sh(unsigned char *buffer) {
+    if ((memcmp(buffer, TRANSACTION_OUTPUT_SCRIPT_P2SH_PRE,
+                    sizeof(TRANSACTION_OUTPUT_SCRIPT_P2SH_PRE)) == 0) &&
+        (memcmp(buffer + sizeof(TRANSACTION_OUTPUT_SCRIPT_P2SH_PRE) + 20,
+                    TRANSACTION_OUTPUT_SCRIPT_P2SH_POST,
+                    sizeof(TRANSACTION_OUTPUT_SCRIPT_P2SH_POST)) == 0)) {
+        return 1;
+    }
     if (G_coin_config->kind == COIN_KIND_HORIZEN) {
         if ((memcmp(buffer, ZEN_TRANSACTION_OUTPUT_SCRIPT_P2SH_PRE,
                        sizeof(ZEN_TRANSACTION_OUTPUT_SCRIPT_P2SH_PRE)) == 0) &&
             (memcmp(buffer + sizeof(ZEN_TRANSACTION_OUTPUT_SCRIPT_P2SH_PRE) + 20,
                        ZEN_TRANSACTION_OUTPUT_SCRIPT_P2SH_POST,
                        sizeof(ZEN_TRANSACTION_OUTPUT_SCRIPT_P2SH_POST)) == 0)) {
-            return 1;
-        }
-    } else {
-        if ((memcmp(buffer, TRANSACTION_OUTPUT_SCRIPT_P2SH_PRE,
-                       sizeof(TRANSACTION_OUTPUT_SCRIPT_P2SH_PRE)) == 0) &&
-            (memcmp(buffer + sizeof(TRANSACTION_OUTPUT_SCRIPT_P2SH_PRE) + 20,
-                       TRANSACTION_OUTPUT_SCRIPT_P2SH_POST,
-                       sizeof(TRANSACTION_OUTPUT_SCRIPT_P2SH_POST)) == 0)) {
             return 1;
         }
     }


### PR DESCRIPTION
This PR fixes the support for Horizen blockchain.

The previous implementation was only taking into account outputs including the **replay protection**.

That made sense as replay protection is mandatory, but it didn't take into account the release of **Zendoo** and the fact that sidechain certificates include **Backward Transfers** (outputs) **without replay protection**.
